### PR TITLE
create legacy boot image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ QUIET = @
 # See https://doc.rust-lang.org/cargo/reference/environment-variables.html
 export CARGO_TARGET_DIR=$(PWD)/target
 
-.PHONY: all check clean libc_musl microkernel run run_nogui runtime_environment roottask static_foreign_apps userland_tarball
+.PHONY: all bootimage check clean libc_musl microkernel run run_nogui runtime_environment roottask static_foreign_apps userland_tarball
 
 # "make" builds everything
 # userland tarball itself depends on "runtime_environment static_foreign_apps"
@@ -91,11 +91,16 @@ check:
 	$(QUIET).build_helpers/check_repo.sh
 	$(QUIET).build_helpers/check_machine.sh
 
-# Prepares the files for the network-boot. This is special to my
-# local setup on my developer machine, where remote computers are
-# connected via LAN and load files via TFTP from my laptop.
-networkboot:
-# TODO
+# Creates a bootable image with GRUB 2 as bootloader that boots in a legacy
+# x86 boot environment. GRUB 2 is used to dispatch to Hedron via Multiboot 2.
+bootimage:
+	rm -rf grub/iso
+	mkdir -p grub/iso/boot/grub
+	cp grub/grub.cfg grub/iso/boot/grub/grub.cfg
+	cp $(BUILD_DIR)/hedron.elf32 grub/iso/hedron
+	cp $(BUILD_DIR)/roottask-bin grub/iso/roottask.elf
+	cp $(BUILD_DIR)/userland.tar grub/iso/userland.tar
+	grub-mkrescue -o grub/legacy_boot_x86.img grub/iso
 
 clean:
 	rm -rf $(BUILD_DIR) $(CARGO_TARGET_DIR)

--- a/README.md
+++ b/README.md
@@ -97,12 +97,16 @@ execute `git submodule update --init --recursive` again. I really have no clue w
   above. Otherwise, you may see "BOOTING FROM ROM..." for 20+ seconds, until something happens.
 
 
-
 You should use `$ make run_nogui` on headless systems, such as when you are connected via SSH to a remote machine. The
 regular `make run` opens a GUI window with a VGA buffer for Hedron.
 
 All output from the roottask/the runtime environment gets printed to serial (which QEMU maps to stdout) and also
 to `qemu_debugcon.txt`.
+
+### Boot on Real Hardware
+Currently, Hedron doesn't boot on UEFI without the closed-source UEFI loader of Cyberus Technology GmbH.
+However, you can boot my project on real hardware that supports a legacy boot x86 boot flow (on UEFI systems the
+CSM mode should work as well). Type `make && make bootimage` and write `legacy_boot_x86.img` to a USB drive or a CD.
 
 ### Build Troubleshooting
 - git submodule init fails: \

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Currently, Hedron doesn't boot on UEFI without the closed-source UEFI loader of 
 However, you can boot my project on real hardware that supports a legacy boot x86 boot flow (on UEFI systems the
 CSM mode should work as well). Type `make && make bootimage` and write `legacy_boot_x86.img` to a USB drive or a CD.
 
+The roottask will print information to the serial device (COM1 port) but not to the VGA framebuffer. Thus, you will
+only see output from Hedron on the screen so far. Currently, there is no nice mechanism to enable the roottask to
+print to a framebuffer.
+
 ### Build Troubleshooting
 - git submodule init fails: \
   I have no clue why this fails sometimes. If so, it probably works

--- a/grub/.gitignore
+++ b/grub/.gitignore
@@ -1,0 +1,6 @@
+# the directory that becomes the ISO for the legacy
+# GRUB boot image
+/iso
+
+# generated aritfact
+*.img

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,14 @@
+# GRUB configuration that bootstraps Hedron, the roottask,
+# and the userland via Multiboot2.
+
+set timeout=0
+set default=0
+# set debug=all
+
+menuentry "Hedron + Diplom Thesis Roottask" {
+    # the leading slash is very important..
+    multiboot2 /hedron serial
+    module2 /roottask.elf
+    module2 /userland.tar userland
+    boot
+}


### PR DESCRIPTION
This MR introduces the `make bootimage` command that enables to boot everything on a USB flash drive.